### PR TITLE
Update smooshed.txt, Fixed hang caused by wf_music.zs and WadfusionMusicHandler with mp3 versions of sigil 1 and 2

### DIFF
--- a/res/mapinfo.txt
+++ b/res/mapinfo.txt
@@ -40,7 +40,7 @@ GameInfo
 		"$QUITMSG4", "$QUITMSG5", "$QUITMSG6", "$QUITMSG7", "$QUITMSG8",
 		"$QUITMSG9", "$QUITMSG10", "$QUITMSG11", "$QUITMSG12",
 		"$QUITMSG13", "$QUITMSG14"
-	AddEventHandlers = "WadSmooshHandler", "WadFusionMusicHandler"//, "Id1WeaponHandler"
+	AddEventHandlers = "WadSmooshHandler", "Id1WeaponHandler"
 }
 
 clearepisodes

--- a/res/smooshed.txt
+++ b/res/smooshed.txt
@@ -1,2 +1,2 @@
 This file was created by WadSmoosh Plus:
-https://github.com/staticnation/wadsmoosh-plus
+https://github.com/vanessakindell/wadsmoosh-plus

--- a/res/zscript.txt
+++ b/res/zscript.txt
@@ -2,7 +2,6 @@
 version "4.1.0"
 
 #include "zscript/wf_handler.zs"
-#include "zscript/wf_music.zs"
 #include "zscript/wf_xbox.zs"
 #include "zscript/wf_sbar.zs"
 //#include "zscript/wf_id1weap.zs"

--- a/wadsmoosh_data.py
+++ b/wadsmoosh_data.py
@@ -70,7 +70,7 @@ RES_FILES = [
     'mapinfo/tntr_levels.txt','mapinfo/pl2_levels.txt','mapinfo/prcp_levels.txt',
     'mapinfo/jptr_levels.txt',
     'menudef.txt', 'cvarinfo.txt', 'zscript.txt', 'DEHACKED.txt',
-    'zscript/wf_handler.zs', 'zscript/wf_music.zs', 'zscript/wf_sbar.id1.zs', 'zscript/wf_xbox.zs'
+    'zscript/wf_handler.zs', 'zscript/wf_sbar.id1.zs', 'zscript/wf_xbox.zs'
 ]
 
 # files within pk3 dir that will be removed before a new run


### PR DESCRIPTION
updated smooshed.txt to reflect https://github.com/vanessakindell/wadsmoosh-plus/ and not https://github.com/staticnation/wadsmoosh-plus/

stripped WadfusionMusicHandler and wf_music.zs as it is busted and will cause the game to hang on load if using the mp3 versions of sigil, sigil2, etc

The wadfusion music scripts are not needed are not correct for the data structure of wadsmoosh-plus
they have logic for IDKFA (not used by this fork)
logic for mp3 <-> midi switching for Sigil 1 & 2 (alternate tracks are not dumped by wadsmoosh-plus so causes hang on load)
plutonia tracks are already set to what the script would change them too (original "h_" prefix tracks are not dumped by wadsmoosh-plus)